### PR TITLE
Fix display rename presets when the name is too long and fix showing "no changes made" popup

### DIFF
--- a/bbbeasy-frontend/src/App-webapp.css
+++ b/bbbeasy-frontend/src/App-webapp.css
@@ -1587,7 +1587,11 @@ div.error-message-Label {
     margin-bottom: 10px;
     margin-left: 10px;
 }
-
+.preset-name {
+    max-width: 120px !important;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 .ant-table-cell {
     max-width: 150px !important;
 }

--- a/bbbeasy-frontend/src/components/Presets.tsx
+++ b/bbbeasy-frontend/src/components/Presets.tsx
@@ -278,7 +278,13 @@ const PresetsCol: React.FC<PresetColProps> = ({
                         <Space>
                             {!isEditing ? (
                                 <>
-                                    <span>{preset['name']}</span>
+                                    <Tooltip
+                                        key="tooltipLabels"
+                                        overlayClassName="install-tooltip"
+                                        title={preset['name']}
+                                    >
+                                        <div className='preset-name'>{preset['name']}</div>
+                                    </Tooltip>
                                     {isShown && editName && !isDefault && (
                                         <Button
                                             className="edit-btn"
@@ -645,6 +651,10 @@ const Presets = () => {
 
     //edit
     const editPreset = (newPreset: MyPresetType, oldPreset: MyPresetType) => {
+        if(newPreset.name == oldPreset.name){
+            Notifications.openNotificationWithIcon('info', t('no_changes'));
+            return
+        }
         const newPresets = [...myPresets];
         const index = newPresets.findIndex((item) => oldPreset.id === item.id);
         if (index > -1 && newPreset != undefined) {


### PR DESCRIPTION
## **Description**


## **Changes Made**


## **Closes Issue(s)**

## **Related Issue(s)**
https://github.com/riadvice/bbbeasy/issues/895
https://github.com/riadvice/bbbeasy/issues/894
## **Types of changes**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Automated testing implementation or update
- [ ] Dependencies updated to a newer version
- [ ] Documentation update
- [ ] Experimental feature that requires further discussion

## **Screenshots and screen captures**

<img width="734" alt="image" src="https://github.com/riadvice/bbbeasy/assets/45165289/80c9ad42-73f0-4bd2-8b84-30feef540173">

<img width="756" alt="image" src="https://github.com/riadvice/bbbeasy/assets/45165289/aaa3846d-439e-48b9-9a76-cf8eb154f44e">


<img width="754" alt="image" src="https://github.com/riadvice/bbbeasy/assets/45165289/1724087e-4bfb-4132-bf71-ec9cbd113766">
